### PR TITLE
Af/export ev sim

### DIFF
--- a/src/EVQueues.jl
+++ b/src/EVQueues.jl
@@ -2,7 +2,7 @@ module EVQueues
 
 using ProgressMeter, Distributions, Serialization, JuMP, GLPK, DataFrames
 
-export  compute_statistics!, compute_fairness, generate_Poisson_stream,
+export  compute_statistics!, compute_fairness, generate_Poisson_stream, ev_sim_trace,
         EVSim, loadsim, savesim
 
 mutable struct EVinstance

--- a/src/policies.jl
+++ b/src/policies.jl
@@ -456,3 +456,39 @@ function edffixed_policy(evs::Array{EVinstance},C::Float64)
 end
 
 @addpolicy("edffixed")
+
+function edfc_policy(evs::Array{EVinstance},C::Float64)
+
+
+    if length(evs)==0
+        #nothing to do, return empty array for consistence
+        U=Array{Float64}(undef,0);
+    else
+        deadlines = [ev.currentReportedDeadline for ev in evs];
+
+        positivas = findall(deadlines.>0)
+        negativas = findall(deadlines.<=0)
+
+        perm1 = sortperm(deadlines[positivas]);
+        perm2 = sortperm(deadlines[negativas], rev=true);
+
+        perm = [positivas[perm1];negativas[perm2]]
+        
+        p=0.0;
+        i=1;
+        U=zeros(length(evs));
+
+        #recorro el vector en orden de deadline y le asigno su potencia maxima o lo que falte pare llegar a C (puede ser 0)
+        while p<C && i<=length(evs)
+            alloc = min(evs[perm[i]].chargingPower,C-p);
+            p=p+alloc;
+            U[perm[i]]=alloc;
+            i=i+1;
+        end
+
+    end
+    return U;
+
+end
+
+@addpolicy("edfc")

--- a/src/utilities.jl
+++ b/src/utilities.jl
@@ -12,7 +12,7 @@ end
 
 function compute_statistics!(sim::EVSim,t_start,t_end)
 
-    idx = sim.timetrace.T.>t_start && sim.timetrace.T.<t_end
+    idx = findall(t_start.<=sim.timetrace.T.<t_end)
     sim.stats.avgX = compute_average(x->x,sim.timetrace.T[idx],sim.timetrace.X[idx]);
     sim.stats.avgY = compute_average(x->x,sim.timetrace.T[idx],sim.timetrace.Y[idx]);
 

--- a/src/utilities.jl
+++ b/src/utilities.jl
@@ -10,7 +10,7 @@ function compute_average(f,T::Vector{Float64},X::Vector{UInt16})
     return sum(f(X[1:end-1]).*diff(T))/T[end]
 end
 
-function comput_statistics!(sim::EVsim,t_start,t_end)
+function comput_statistics!(sim::EVSim,t_start,t_end)
 
     idx = sim.timetrace.T.>t_start && sim.timetrace.T.<t_end
     sim.stats.avgX = compute_average(x->x,sim.timetrace.T[idx],sim.timetrace.X[idx]);

--- a/src/utilities.jl
+++ b/src/utilities.jl
@@ -10,7 +10,7 @@ function compute_average(f,T::Vector{Float64},X::Vector{UInt16})
     return sum(f(X[1:end-1]).*diff(T))/T[end]
 end
 
-function comput_statistics!(sim::EVSim,t_start,t_end)
+function compute_statistics!(sim::EVSim,t_start,t_end)
 
     idx = sim.timetrace.T.>t_start && sim.timetrace.T.<t_end
     sim.stats.avgX = compute_average(x->x,sim.timetrace.T[idx],sim.timetrace.X[idx]);


### PR DESCRIPTION
Exported ev_sim_trace for policy definition outside the library. Plus some minor fixes: enhanced compute_statistics!(sim,t_start,t_end) and a new policy edf curtailed.